### PR TITLE
Easing up on the language regarding our response.

### DIFF
--- a/code-of-conduct-contact.md
+++ b/code-of-conduct-contact.md
@@ -9,7 +9,7 @@ If that's the case, the identities of all victims and reporters will remain conf
 If you believe anyone is in physical danger, please notify appropriate law enforcement first.
 If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
 
-If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this Code of Conduct, we encourage you to still report it.
+If you are unsure whether the incident is a violation, or whether the space where it happened is covered by our code of conduct, we encourage you to still report it.
 We would much rather have a few extra reports where we decide to take no action, than miss a report of an actual violation.
 
 We do not look negatively on you if we find the incident is not a violation.
@@ -31,16 +31,16 @@ And knowing about incidents that are not violations, or happen outside our space
 
 We promise to acknowledge the issue with a reply within 24 hours _(and will aim for much quicker than that)_.
 
-The working group will immediately meet to review the incident and determine:
+The consortium will meet to review the incident and determine:
 
 - What happened.
 - Whether this event constitutes a code of conduct violation.
 - Who the bad actor was.
 - Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
-- If this is determined to be an ongoing incident or a threat to physical safety, the working groups' immediate priority will be to protect everyone involved.
+- If this is determined to be an ongoing incident or a threat to physical safety, the consortiums' immediate priority will be to protect everyone involved.
     This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
 
-Once the working group has a complete account of the events they will make a decision as to how to response. Responses may include:
+The consortium will give their best effort responding to the situation and responses may include:
 
 - Nothing _(if we determine no violation occurred)_.
 - A private reprimand from the working group to the individual(s) involved.
@@ -48,14 +48,12 @@ Once the working group has a complete account of the events they will make a dec
 - An imposed vacation _(i.e. asking someone to "take a week off" from a mailing list or IRC)_.
 - A permanent or temporary ban from some or all Dat Ecosystem spaces _(Discord Chat, mailing lists, IRC, etc.)_.
 - A request for a public or private apology.
+- A public incident report.
 
-We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
-
-Once we've determined our final action, we'll contact the original reporter to let them know what action _(if any)_ we'll be taking.
+We'll respond as soon as we can to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+Futhermore, once we've determined our final action, we'll let them know what action _(if any)_ we'll be taking.
 
 We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
-
-The consortium members may choose to a public report of the incident.
 
 ## What if your report concerns a possible violation by a consortium member?
 
@@ -64,7 +62,7 @@ as all members will see the report.
 
 In that case, you can make a report directly to any or all other workgroup group or consortium members. Their means of contact are listed on the [Manifesto](./MANIFESTO.md).
 
-The consortium will follow the usual enforcement process with the other members, but will exclude the member(s) that the report concerns from any discussion or decision making.
+The members you contact will respond to the issue, to the best of their ability, in a group excluding the member(s) that the report concerns.
 
 ## Reconsideration
 


### PR DESCRIPTION
_(This is an amendment to PR #1)_

@serapath [pointed out](https://github.com/dat-ecosystem/organization/pull/1#discussion_r596482235) that the obligations in the contact have been too strict.

While I am not okay with removing the reporting guidelines as whole - I believe they are important to set expectations for people that are in a difficult situation - I can see the point that they may impose duties on us that we can not uphold. As such this PR attempts to soften the language in a way that still should be useful to the person that needs the code of conduct without putting the consortium under unrealistic duties.

_Aside: I am sorry for this to be delayed, I didn't have it in me to propose a change in the past 48h._