### PR TITLE
update dat-ecosystem manifesto

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -4,7 +4,7 @@ We, the "Dat Ecosystem" members, come together to achieve the following goals:
 
 - Share our knowledge on building decentralized systems.
 - Publish our work under permissive, open culture, licenses.
-- Build decentralized systems that profit the general public.
+- Build decentralized systems that profit the general public and empower users.
 - Have dat protocols (e.g. [hypercore-protocol][1] or similar) as a foundation of our work.
 - Promote our shared goals with the public.
 - Develop solutions to shared technical problems.
@@ -20,7 +20,7 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 - Coordinate efforts by members.
 - Communicate on [discord/cabal](https://github.com/dat-ecosystem/dat-ecosystem.github.io#join-the-dat-ecosystem-chat-network)
 
-Proposals are submitted as pull requests to `/consortium/decisions/${YYY}.${MM}.${DD}-${proposal_name}.md` in the organisation repository.  
+Proposals are submitted as pull requests to `/consortium/decisions/${YYY}.${MM}.${DD}-${proposal_name}.md` in this repository.  
 Proposer needs to tag all consortium members in the pull request and notify consortium members in the active consortium communication channel.
 
 Decisions will be done through voting by consortium members. The voting period lasts 2 weeks.  
@@ -28,9 +28,9 @@ Regular voting items are accepted unless there is opposition by at least one Con
 
 The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members.  
 The removal of one member requires unanimous support by all Consortium members except by the member in question.  
-After a consortium member is tagged in the proposals pull request and the consortium communication channel and that member does not respond within 3 months, their consortium membership becomes dormant, which means they do not count as consortium member in the context of deciding about proposals.  
-Dormant consortium members can reactivate themselves at any given time.  
-Consortium Members can end their consortium membership and remove themselves from the consortium membership list at any given time.
+After a consortium member is tagged in a proposals pull request and the consortium communication channel and that member does not respond within 3 months, their consortium membership becomes dormant, which means they do not count as consortium member in the context of deciding about any proposals.  
+Dormant consortium members can reactivate themselves at any given time to become normal consortium members again unilateraly.
+Consortium Members can end their consortium membership and remove themselves from the consortium membership list at any given time unilateraly.
 
 [1]: https://hypercore-protocol.org
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -20,12 +20,17 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 - Coordinate efforts by members.
 - Communicate on [discord/cabal](https://github.com/dat-ecosystem/dat-ecosystem.github.io#join-the-dat-ecosystem-chat-network)
 
-Proposals can be submited as pull requests to the organisation repository under `/consortium/decisions/${YYY}.${MM}.${DD}-${proposal_name}.md`.
+Proposals are submitted as pull requests to `/consortium/decisions/${YYY}.${MM}.${DD}-${proposal_name}.md` in the organisation repository.  
 Proposer needs to tag all consortium members in the pull request and notify consortium members in the active consortium communication channel.
 
-Decisions will be done through voting by consortium members. The voting period lasts 2 weeks. Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.
+Decisions will be done through voting by consortium members. The voting period lasts 2 weeks.  
+Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.
 
-The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question. After a consortium member is tagged in the proposals pull request and the consortium communication channel and that member does not respond within 3 months, their consortium membership becomes dormant, which means they do not count as consortium member in the context of deciding about proposals. Dormant consortium members can reactivate themselves at any given time. Consortium Members can end their consortium membership and remove themselves from the consortium membership list at any given time.
+The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members.  
+The removal of one member requires unanimous support by all Consortium members except by the member in question.  
+After a consortium member is tagged in the proposals pull request and the consortium communication channel and that member does not respond within 3 months, their consortium membership becomes dormant, which means they do not count as consortium member in the context of deciding about proposals.  
+Dormant consortium members can reactivate themselves at any given time.  
+Consortium Members can end their consortium membership and remove themselves from the consortium membership list at any given time.
 
 [1]: https://hypercore-protocol.org
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -5,7 +5,7 @@ We, the "Dat Ecosystem" members, come together to achieve the following goals:
 - Share our knowledge on building decentralized systems.
 - Publish our work under permissive, open culture, licenses.
 - Build decentralized systems that profit the general public.
-- Have the [hypercore-protocol][1] or similar decentralized technology as a foundation of our work.
+- Have dat protocols (e.g. [hypercore-protocol][1] or similar) as a foundation of our work.
 - Promote our shared goals with the public.
 - Develop solutions to shared technical problems.
 - Find and invite new members that share our goals.
@@ -18,10 +18,14 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 - Use decentralized systems wherever feasible.
 - Publicly and transparently document the process and offer the public a means to comment.
 - Coordinate efforts by members.
+- Communicate on [discord/cabal](https://github.com/dat-ecosystem/dat-ecosystem.github.io#join-the-dat-ecosystem-chat-network)
 
-Decisions will be done through votes at our meetings. The voting items need to be shared at least 48 hours in advance with all consortium members. Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.
+Proposals can be submited as pull requests to the organisation repository under `/proposals/${YYY}.${MM}.${DD}-${proposal_name}.md`.
+Proposer needs to tag all consortium members in the pull request and notify consortium members in the active consortium communication channel.
 
-The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question. Members can remove themselves at any given time.
+Decisions will be done through voting by consortium members. The voting period lasts 2 weeks. Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.
+
+The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question. After a consortium member is tagged in the proposals pull request and the consortium communication channel and that member does not respond within 3 months, their consortium membership becomes dormant, which means they do not count as consortium member in the context of deciding about proposals. Dormant consortium members can reactivate themselves at any given time. Consortium Members can end their consortium membership and remove themselves from the consortium membership list at any given time.
 
 [1]: https://hypercore-protocol.org
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -22,7 +22,7 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 
 Decisions will be done through votes at our meetings. The voting items need to be shared at least 48 hours in advance with all consortium members. Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.
 
-The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question.
+The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question. Members can remove themselves at any given time.
 
 [1]: https://hypercore-protocol.org
 
@@ -32,7 +32,6 @@ Consortium members _(alphabetic order)_:
 - [Alexander Praetorius](https://github.com/serapath)
 - [Diego Paez](https://github.com/dpaez)
 - [Franz Heinzmann](https://github.com/frando)
-- [Martin Heidegger](https://github.com/martinheidegger)
 - [Kevin Faaborg](https://github.com/zootella)
 - [Mauve](https://github.com/rangermauve)
 - [Nina Breznik](https://github.com/nbreznik)

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -20,7 +20,7 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 - Coordinate efforts by members.
 - Communicate on [discord/cabal](https://github.com/dat-ecosystem/dat-ecosystem.github.io#join-the-dat-ecosystem-chat-network)
 
-Proposals can be submited as pull requests to the organisation repository under `/proposals/${YYY}.${MM}.${DD}-${proposal_name}.md`.
+Proposals can be submited as pull requests to the organisation repository under `/consortium/decisions/${YYY}.${MM}.${DD}-${proposal_name}.md`.
 Proposer needs to tag all consortium members in the pull request and notify consortium members in the active consortium communication channel.
 
 Decisions will be done through voting by consortium members. The voting period lasts 2 weeks. Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -5,7 +5,7 @@ We, the "Dat Ecosystem" members, come together to achieve the following goals:
 - Share our knowledge on building decentralized systems.
 - Publish our work under permissive, open culture, licenses.
 - Build decentralized systems that profit the general public.
-- Have the [hypercore-protocol][1] as a foundation of our work.
+- Have the [hypercore-protocol][1] or similar decentralized technology as a foundation of our work.
 - Promote our shared goals with the public.
 - Develop solutions to shared technical problems.
 - Find and invite new members that share our goals.

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -21,6 +21,7 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 - Communicate on [discord/cabal](https://github.com/dat-ecosystem/dat-ecosystem.github.io#join-the-dat-ecosystem-chat-network)
 
 Proposals are submitted as pull requests to `/consortium/decisions/${YYY}.${MM}.${DD}-${proposal_name}.md` in this repository.  
+Proposals to change the manifesto are submitted as pull requests to change the manifesto itself.
 Proposer needs to tag all consortium members in the pull request and notify consortium members in the active consortium communication channel.
 
 Decisions will be done through voting by consortium members. The voting period lasts 2 weeks.  

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -16,7 +16,6 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 - Enact our [code of conduct](./code-of-conduct.md).
 - Raise and maintain funds and assets to fulfill the goals.
 - Use decentralized systems wherever feasible.
-- Meet every two weeks with an agenda.
 - Publicly and transparently document the process and offer the public a means to comment.
 - Coordinate efforts by members.
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -22,7 +22,7 @@ This group is **governed by individuals** that form together _"the Consortium"_.
 
 Decisions will be done through votes at our meetings. The voting items need to be shared at least 48 hours in advance with all consortium members. Regular voting items are accepted unless there is opposition by at least one Consortium member. Members may state opposition beforehands.
 
-The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question. Members can remove themselves at any given time.
+The addition of a member or changes to this Manifesto requires unanimous support by all Consortium members. The removal of one member requires unanimous support by all Consortium members except by the member in question.
 
 [1]: https://hypercore-protocol.org
 
@@ -32,6 +32,7 @@ Consortium members _(alphabetic order)_:
 - [Alexander Praetorius](https://github.com/serapath)
 - [Diego Paez](https://github.com/dpaez)
 - [Franz Heinzmann](https://github.com/frando)
+- [Martin Heidegger](https://github.com/martinheidegger)
 - [Kevin Faaborg](https://github.com/zootella)
 - [Mauve](https://github.com/rangermauve)
 - [Nina Breznik](https://github.com/nbreznik)


### PR DESCRIPTION
@cblgh 
@pfrazee 
@ninabreznik
@RangerMauve 
@zootella 
@Frando 
@dpaez 
@serapath

**Changes:**
1. remove Martin Heidegger from the consortium members as requested by him.
2. remove the need for meeting every 2 weeks and update voting mechanism accordingly
3. add rule for consortium members to quit the consortium.
4. add rule for inactive consortium members to become dormant indefinitely in voting contexts
   * but keep the option to re-activate themselves in the future


**Additionally:**
In the past, on `2021.01.11` we agreed on the [shared intent](https://github.com/dat-ecosystem/organization/blob/main/consortium/archive/2021.01.11%20_%20Intent%20for%20a%20Dat%20Ecosystem%20Manifesto.md) to have a manifesto. Not all goals expressed found their way into the manifesto yet and it might require another proposal to change that.

This proposal includes the goal to support projects (=dat ecosystem members) that **empower users**.